### PR TITLE
fixes for dragonflight and upping the limit to 35

### DIFF
--- a/CQuestCounter.toc
+++ b/CQuestCounter.toc
@@ -1,6 +1,6 @@
-## Interface: 90001
+## Interface: 100002
 ## Title: CQuestCounter
 ## Author: Centella of Medivh-US
 ## Notes: Adds a counter for how many quests are in your log.|n|cFF00FF00Author: |rCentella of Medivh-US
-## Version: 1.4
+## Version: 1.5
 CQuestCounter.xml

--- a/CQuestCounter.xml
+++ b/CQuestCounter.xml
@@ -4,10 +4,10 @@
         <Size><AbsDimension x="75" y="25" /></Size>
         <Layers>
             <Layer level="OVERLAY">
-                <FontString name="$parentString" font="GameFontNormalLarge" text="Quests: X/25" parent="CQCounterFrame">
+                <FontString name="$parentString" font="GameFontNormal" text="Quests: X/35">
                     <Color r="1" g=".8046" b="0" a="1"/>
                     <Anchors>
-                        <Anchor point="TOPLEFT" relativeTo="QuestScrollFrame" relativePoint="TOPLEFT" x="2" y="22">
+                        <Anchor point="TOPLEFT" relativeTo="QuestScrollFrame" relativePoint="TOPRIGHT" x="-150" y="0">
                         </Anchor>
                     </Anchors>
                 </FontString>
@@ -17,11 +17,11 @@
             <OnLoad>
                 CQCounterFrame:RegisterEvent("QUEST_LOG_UPDATE");
                 local _, k = C_QuestLog.GetNumQuestLogEntries();
-                CQCounterFrameString:SetText(QUESTS_COLON.." "..k.."/25");
+                CQCounterFrameString:SetText(QUESTS_COLON.." "..k.."/35");
             </OnLoad>
             <OnEvent>
                 local _, k = C_QuestLog.GetNumQuestLogEntries();
-                CQCounterFrameString:SetText(QUESTS_COLON.." "..k.."/25");
+                CQCounterFrameString:SetText(QUESTS_COLON.." "..k.."/35");
             </OnEvent>
         </Scripts>
     </Frame>  


### PR DESCRIPTION
Contains:
- fixes from [CurseForge comments](https://www.curseforge.com/wow/addons/cquestcounter?comment=42)
- upping the cap for quests from `25` to `35`
- Updating the `Interface` version to `100002`